### PR TITLE
`npm update`: bumps minor version of tree-sitter-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,46 @@
 {
   "name": "tree-sitter-phpdoc",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "tree-sitter-phpdoc",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.15.0"
+      },
+      "devDependencies": {
+        "tree-sitter-cli": "^0.16.4"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+    },
+    "node_modules/tree-sitter-cli": {
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.16.9.tgz",
+      "integrity": "sha512-Aguz2Ns7qG6t71MP9odhh4t9q3+f29BAmZq8XsTDMtoi5o/e9k+Umeqz6brNngCAz3vMBl1OX95ozdnYzhJWIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "tree-sitter": "cli.js"
+      }
+    }
+  },
   "dependencies": {
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "tree-sitter-cli": {
-      "version": "0.16.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.16.4.tgz",
-      "integrity": "sha512-akCVeK7oOZD+frizRbBx3h6OBlVBxOCNtfpt9nz3zvOdRuJTwoyJUshzF28J+hfcuvQ+yfoZx9/R+2S7NZE2TA==",
+      "version": "0.16.9",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.16.9.tgz",
+      "integrity": "sha512-Aguz2Ns7qG6t71MP9odhh4t9q3+f29BAmZq8XsTDMtoi5o/e9k+Umeqz6brNngCAz3vMBl1OX95ozdnYzhJWIA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "tree-sitter-cli": "^0.16.4"
   },
   "dependencies": {
-    "nan": "^2.14.0"
+    "nan": "^2.15.0"
   }
 }


### PR DESCRIPTION
Generated files are not affected.

Fixes https://github.com/nvim-treesitter/nvim-treesitter/issues/2323

`nan` update is not necessary. For `npm install` to succede the minor version of tree-sitter-cli has to be bumped. Maybe it's even just the update to the new lockfile format that makes the difference.